### PR TITLE
Make start.sh self-contained

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
+# Determine the directory of this script
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Navigate to your project root
-cd /Users/laney/dev/404core
+cd "$DIR"
 
 # Open key files in VS Code
 code index.html style.css js/main.js
 
 # Start Tailwind watcher
-osascript -e 'tell application "iTerm" to do script "cd /Users/laney/dev/404core && npx tailwindcss -i ./style.css -o ./output.css --watch"'
+osascript -e "tell application \"iTerm\" to do script \"cd ${DIR} && npx tailwindcss -i ./style.css -o ./output.css --watch\""
 
 # Start local server in a new tab
-osascript -e 'tell application "iTerm" to do script "cd /Users/laney/dev/404core && npx serve ."'
+osascript -e "tell application \"iTerm\" to do script \"cd ${DIR} && npx serve .\""
 


### PR DESCRIPTION
## Summary
- make start.sh compute its own directory so paths are portable

## Testing
- `npm test` *(fails: `Error: no test specified`)*